### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,7 +123,7 @@ function App() {
             iconUrl: `https://skillicons.dev/icons?i=${cleanIcon}`
           };
         })
-        .filter(Boolean);
+         .filter((item): item is HexagonData => item !== null);
 
       setHexagons(hexagonData);
       setSuccessMessage(`Successfully generated ${icons.length} hexagon badge(s)!`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,15 +108,22 @@ function App() {
         return;
       }
 
-      const hexagonData: HexagonData[] = icons.map(icon => {
-        const cleanIcon = icon.trim();
-        const techInfo = techColors[cleanIcon.toLowerCase()] || { bg: '#667eea', name: cleanIcon };
-        return {
-          iconName: cleanIcon,
-          techInfo,
-          iconUrl: `https://skillicons.dev/icons?i=${cleanIcon}`
-        };
-      });
+      const hexagonData: HexagonData[] = icons
+        .map(icon => {
+          const cleanIcon = icon.trim();
+          // Icon name can only be letters, digits, hyphen or underscore
+          if (!/^[a-zA-Z0-9_-]+$/.test(cleanIcon)) {
+            // Optionally skip or sanitize; here we skip the invalid icon
+            return null;
+          }
+          const techInfo = techColors[cleanIcon.toLowerCase()] || { bg: '#667eea', name: cleanIcon };
+          return {
+            iconName: cleanIcon,
+            techInfo,
+            iconUrl: `https://skillicons.dev/icons?i=${cleanIcon}`
+          };
+        })
+        .filter(Boolean);
 
       setHexagons(hexagonData);
       setSuccessMessage(`Successfully generated ${icons.length} hexagon badge(s)!`);


### PR DESCRIPTION
Potential fix for [https://github.com/PhyoeBlitz/badge-generate/security/code-scanning/1](https://github.com/PhyoeBlitz/badge-generate/security/code-scanning/1)

To fix the problem, we need to ensure that the value used as the `src` for the image (i.e., `hexagon.iconUrl`) cannot be tainted in a way that could result in XSS or other attacks. Since URLs constructed based on user input can be a vector for attacks, especially if attackers manage to produce `data:` or `javascript:` URLs, we should validate and sanitize the icon names before constructing the URLs. A robust solution is to validate that `cleanIcon` is comprised only of allowed characters (e.g., alphanumerics and maybe `-`/`_`), which matches expected icon names served by `skillicons.dev`. Then, if an icon name fails validation, ignore it or replace it with a safe default.

Specifically:
- Edit the region around lines 111-119, where icon names from the input are split and processed.
- Add a validation step for allowed icon names (e.g., regex match for alphanumerics and underscores/hyphens).
- Only construct `iconUrl` for valid icon names; otherwise, skip them or sanitize to a default value.

No external packages are needed for this, as the solution only relies on basic JavaScript/TypeScript string processing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
